### PR TITLE
field-default-factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ __pycache__/
 # Docs
 **/_toctree/*
 
+WIP.md
+
 # Distribution / packaging
 .Python
 build/

--- a/miv/statistics/connectivity/connectivity.py
+++ b/miv/statistics/connectivity/connectivity.py
@@ -8,7 +8,7 @@ import itertools
 import logging
 import os
 import pathlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import matplotlib.pyplot as plt
@@ -53,7 +53,7 @@ class DirectedConnectivity(OperatorMixin):
 
     mea: str = None
     channels: list[int] | None = None
-    exclude_channels: list[int] | None = None
+    exclude_channels: list[int] = field(default_factory=list)
     bin_size: float = 0.001
     minimum_count: int = 1
     tag: str = "directional connectivity analysis"
@@ -74,9 +74,6 @@ class DirectedConnectivity(OperatorMixin):
             self.mea_map = mea_map[self.mea]
         else:
             self.mea_map = mea_map["64_intanRHD"]
-
-        if self.exclude_channels is None:  # FIXME: Use dataclass default value
-            self.exclude_channels = []
 
     @cache_call
     def __call__(self, spikestamps: Spikestamps) -> np.ndarray:
@@ -407,7 +404,7 @@ class UndirectedConnectivity(OperatorMixin):
         Random seed. If None, use random seed, by default None
     """
 
-    exclude_channels: list[int] | None = None
+    exclude_channels: list[int] = field(default_factory=list)
     bin_size: float = 0.001
     minimum_count: int = 1
     firing_rate_limit: float = 5e-1
@@ -424,8 +421,6 @@ class UndirectedConnectivity(OperatorMixin):
 
     def __post_init__(self):
         super().__init__()
-        if self.exclude_channels is None:  # FIXME: Use dataclass default value
-            self.exclude_channels = []
 
     @cache_call
     def __call__(self, spikestamps: Spikestamps, mea=None) -> np.ndarray:


### PR DESCRIPTION
# Description

This PR fixes the initialization of `exclude_channels` in the `DirectedConnectivity` and `UndirectedConnectivity` classes by using the proper dataclass field default factory pattern instead of manually initializing in `__post_init__`. The change removes the FIXME comments and simplifies the code.

Additionally, adds `WIP.md` to the `.gitignore` file to exclude work-in-progress documentation from version control.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] `make test`

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings/errors
- [x] Any dependent changes have been addressed and published in downstream modules