### PR TITLE
docstring-update

### DIFF
--- a/miv/mea/grid.py
+++ b/miv/mea/grid.py
@@ -86,8 +86,15 @@ class GridMEA(MEAMixin, MEAutility.core.MEA):
         return self.Xn, self.Yn, value_grid
 
     def get_ixiy(self, channel: int):
-        # FIXME: ixiy return ys xs
-        """Given node index, return x y coordinate index"""
+        """Given node index, return grid coordinate indices.
+
+        Returns
+        -------
+        tuple[int, int] | None
+            A tuple of (row_index, column_index) for the channel in the grid.
+            Returns None if the channel is not found in the grid.
+            The indices can be used for array indexing: grid[row_index, column_index]
+        """
         if channel not in self.grid:
             return None
         ys, xs = np.where(self.grid == channel)


### PR DESCRIPTION
# Description

Improved the documentation for the `get_ixiy` method in the MEA grid class by adding detailed return type information and clarifying that the method returns row and column indices. The updated docstring now explicitly states that the return value is a tuple of (row_index, column_index) or None if the channel is not found, and explains how these indices can be used for array indexing.

Fixes the FIXME comment that noted the return order was (ys, xs) rather than (x, y) as might be expected.

@neuroinformatics-team

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `make test`

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings/errors
- [x] New and existing unit tests pass locally with my changes
- [x] There are no other PR/Issues that is blocking this PR.