### PR TITLE
update return hinting

### DIFF
--- a/miv/mea/grid.py
+++ b/miv/mea/grid.py
@@ -85,7 +85,7 @@ class GridMEA(MEAMixin, MEAutility.core.MEA):
             value_grid[:, self.grid == idx] = signal[idx][:, None]
         return self.Xn, self.Yn, value_grid
 
-    def get_ixiy(self, channel: int):
+    def get_ixiy(self, channel: int) -> tuple[int, int] | None:
         """Given node index, return grid coordinate indices.
 
         Returns


### PR DESCRIPTION
# Description

Added type annotation to the `get_ixiy` method in the `grid.py` file to indicate that it returns either a tuple of two integers or None. This improves type safety and code clarity by explicitly documenting the return type of the method.

@neuromorphs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `make test`
- [ ] New tests implementation

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings/errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been addressed and published in downstream modules
- [x] There are no other PR/Issues that is blocking this PR.