### PR TITLE
pr-template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,36 +1,22 @@
-# Description
+## Summary
 
-> Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+Brief description of changes.
 
 Fixes # (issue)
-Related PRs # (pull requests)
 
-@mentions of the person or team responsible for reviewing proposed changes.
+## Type
 
-## Type of change
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Documentation
 
-Please delete options that are not relevant.
+## Testing
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+- [ ] Tests added/updated
 
-# How Has This Been Tested?
+## Checklist
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-
-- [ ] `make test`
-- [ ] New tests implementation
-
-# Checklist:
-
-- [ ] My code follows the style guidelines of this project.
-- [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings/errors
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been addressed and published in downstream modules
-- [ ] There are no other PR/Issues that is blocking this PR.
+- [ ] Code follows style guidelines
+- [ ] Self-reviewed
+- [ ] Tests pass locally


### PR DESCRIPTION
## Simplify PR Template

Streamlined the pull request template to be more concise while maintaining essential information. The new template:

- Reduces verbosity and removes redundant instructions
- Simplifies the type of change section with clearer options
- Condenses the testing and checklist sections to focus on key requirements
- Removes mentions of specific people/teams and related PRs
- Maintains the issue reference format

The template now provides a cleaner structure that's easier to complete while still capturing all necessary information for reviewers.