### PR TITLE
use pytet-raise

### DIFF
--- a/tests/statistics/test_fano_factor.py
+++ b/tests/statistics/test_fano_factor.py
@@ -8,7 +8,6 @@ from miv.statistics import fano_factor
 # Test set for Fano Factor
 
 
-# TODO: Finish implementing fano factor for spiketrain
 def test_fano_factor_output():
     # Initialize the spiketrain as below
     spikestamps = Spikestamps([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
@@ -19,9 +18,9 @@ def test_fano_factor_output():
 def test_fano_factor_empty_spiketrain():
     # Test to throw error in empty spiketrains
     train1 = Spikestamps([])
-    with np.testing.assert_raises(AssertionError):
+    with pytest.raises(AssertionError):
         fano_factor(train1, t_start=10, t_end=1)
     # The function above should throw an error since there are no spike to compute variance and mean
-    with np.testing.assert_raises(AssertionError):
+    with pytest.raises(AssertionError):
         fano_factor(train1, -1)
     # The function above should throw an error since start time cannot be same or greater than end time


### PR DESCRIPTION
## Summary

Replace `np.testing.assert_raises` with `pytest.raises` in the Fano Factor tests for empty spiketrains. This change aligns the test assertions with pytest's standard approach for testing exceptions.

## Type

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation

## Testing

- [x] Tests added/updated

## Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed
- [x] Tests pass locally