### PR TITLE
fix: undefined function name

### DIFF
--- a/miv/statistics/connectivity/connectivity.py
+++ b/miv/statistics/connectivity/connectivity.py
@@ -520,7 +520,7 @@ class UndirectedConnectivity(OperatorMixin):
             rng.shuffle(surrogate_source)
             for start_index in np.arange(0, source.shape[0] - sublength, stride):
                 end_index = start_index + sublength
-                surr_val = func(
+                surr_val = pairwise_granger(
                     np.stack(
                         [
                             surrogate_source[start_index:end_index],


### PR DESCRIPTION
## Summary

Fixed a bug in the `_surrogate_t_test` function by replacing the generic `func` parameter with the specific `pairwise_granger` function call. This ensures the surrogate test correctly uses the Granger causality calculation.

Fixes #

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Testing

- [ ] Tests added/updated

## Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed
- [ ] Tests pass locally