### PR TITLE
enable skip_surrogate

### DIFF
--- a/miv/statistics/connectivity/connectivity.py
+++ b/miv/statistics/connectivity/connectivity.py
@@ -176,7 +176,8 @@ class DirectedConnectivity(OperatorMixin):
         )
         if te < H_threshold:
             return 1, 0
-        return 1, te
+        if skip_surrogate:
+            return 1, te
         t_value, p_value = spst.ttest_1samp(surrogate_te_list, te, nan_policy="omit")
         return p_value, te
 


### PR DESCRIPTION
## Summary

Fixed a bug in the `_get_connection_info` function where the surrogate test was always being performed even when `skip_surrogate` was set to True. Now, when `skip_surrogate` is True, the function correctly returns the transfer entropy value without performing the surrogate test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Testing

- [ ] Tests added/updated

## Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed
- [ ] Tests pass locally