### PR TITLE
Rework on cacher:

### DIFF
--- a/miv/core/cache_write.py
+++ b/miv/core/cache_write.py
@@ -1,0 +1,61 @@
+"""
+Shared rules for persisting computed values through a :class:`~miv.core.cachable._CacherProtocol`.
+
+Used by:
+
+- **Operators** — :class:`~miv.core.operator.operator.OperatorMixin` (scalar) and
+  :class:`~miv.core.operator_generator.operator.GeneratorOperatorMixin` (streaming:
+  per-chunk writes from :meth:`~miv.core.operator_generator.operator.GeneratorOperatorMixin.output`).
+  The legacy :func:`~miv.core.operator_generator.wrapper.cache_generator_call` decorator
+  is deprecated and only adapts the runner's ``(idx, *inputs)`` call to ``__call__``.
+- **Source / data loaders** — when a path writes through
+  :class:`~miv.core.source.cachable.FunctionalCacher`, call this with the same
+  *chunk_index* rules; pass loader-specific arguments (e.g. ``params`` for
+  ``save_config``) via ``**save_config_kwargs`` on the first chunk only.
+
+This module centralizes *when* ``save_cache`` / ``save_config`` run relative to
+chunk index so operator and source paths stay aligned.
+"""
+
+from __future__ import annotations
+
+__all__ = ["persist_cacher_result"]
+
+from typing import Any
+
+from .cachable import _CacherProtocol
+
+
+def persist_cacher_result(
+    cacher: _CacherProtocol,
+    value: Any,
+    *,
+    chunk_index: int = 0,
+    tag: str = "data",
+    **save_config_kwargs: Any,
+) -> None:
+    """
+    Persist one computed chunk through *cacher*.
+
+    Parameters
+    ----------
+    cacher
+        The node's cacher (e.g. :class:`~miv.core.operator.cachable.DataclassCacher`
+        or :class:`~miv.core.source.cachable.FunctionalCacher`).
+    value
+        Payload to pickle; if ``None``, nothing is written.
+    chunk_index
+        File index for chunked caches. Scalar paths use ``0``. Configuration is
+        written only when ``chunk_index == 0`` (first chunk of a logical run).
+    tag
+        Cache file tag (usually ``"data"``).
+    **save_config_kwargs
+        Passed to ``cacher.save_config`` when ``chunk_index == 0``. Source loaders
+        using :class:`~miv.core.source.cachable.FunctionalCacher` typically pass
+        ``params=...``; operator cachers ignore extra keys they do not use.
+    """
+    if value is None:
+        return
+    cacher.save_cache(value, idx=chunk_index, tag=tag)
+    if chunk_index == 0:
+        cacher.save_config(tag=tag, **save_config_kwargs)

--- a/miv/core/operator/operator.py
+++ b/miv/core/operator/operator.py
@@ -13,6 +13,7 @@ import pathlib
 from loguru import logger
 from ..chainable import ChainingMixin
 from ..loggable import DefaultLoggerMixin
+from ..cache_write import persist_cacher_result
 from .cachable import DataclassCacher
 from .callback import BaseCallbackMixin
 from .policy import VanillaRunner, RunnerBase
@@ -95,10 +96,9 @@ class OperatorMixin(ChainingMixin, BaseCallbackMixin, DefaultLoggerMixin):
             else:
                 output = self.runner(self.__call__, args)
 
-            # Save cache after execution (respects policy via when_policy_is decorator)
-            if output is not None:
-                self.cacher.save_cache(output, tag="data")
-                self.cacher.save_config(tag="data")
+            # Save cache after execution (shared seam with generator operators;
+            # policy enforced inside cacher via when_policy_is)
+            persist_cacher_result(self.cacher, output, tag="data")
 
             # Callback: After-run
             self._callback_after_run(output)

--- a/miv/core/operator_generator/operator.py
+++ b/miv/core/operator_generator/operator.py
@@ -1,28 +1,53 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-from collections.abc import Generator
+import itertools
+from typing import Any
+from collections.abc import Generator, Iterable
 
-
-if TYPE_CHECKING:
-    from ..operator.policy import RunnerBase
-
+from ..cache_write import persist_cacher_result
 from ..cachable import CACHE_POLICY
 from ..operator.operator import OperatorMixin
 from .callback import (
     GeneratorCallbackMixin,
 )
-from .policy import VanillaGeneratorRunner
+from .policy import StreamChunkAlignedGeneratorRunner, VanillaGeneratorRunner
 
 
 class GeneratorOperatorMixin(OperatorMixin, GeneratorCallbackMixin):
     def __init__(self) -> None:
         super().__init__()
 
-        self.runner: RunnerBase = VanillaGeneratorRunner(self)  # type: ignore[assignment]
+        self.runner: StreamChunkAlignedGeneratorRunner = VanillaGeneratorRunner(self)
 
     def set_caching_policy(self, policy: CACHE_POLICY) -> None:
         self.cacher.policy = policy
+
+    @staticmethod
+    def _tee_upstream_args(
+        args: list[Iterable[Any]],
+    ) -> tuple[list[Iterable[Any]], list[Iterable[Any]]]:
+        """Fork each upstream iterable so the runner and plot/callback zip stay aligned."""
+        tees = [itertools.tee(a, 2) for a in args]
+        return [t[0] for t in tees], [t[1] for t in tees]
+
+    def _wrap_streaming_chunk_side_effects(
+        self,
+        gen: Generator[Any, None, None],
+        upstream_args: list[Iterable[Any]],
+    ) -> Generator[Any, None, None]:
+        """Persist each chunk and run generator plot hooks (lockstep stream runners only)."""
+        tasks = zip(*upstream_args, strict=True)
+
+        for idx, (result, zip_arg) in enumerate(zip(gen, tasks, strict=True)):
+            persist_cacher_result(self.cacher, result, chunk_index=idx, tag="data")
+            self._callback_generator_plot(
+                idx, result, zip_arg, save_path=self.analysis_path
+            )
+            if idx == 0:
+                self._callback_firstiter_plot(
+                    result, zip_arg, save_path=self.analysis_path
+                )
+            yield result
 
     def output(self) -> Generator:
         """
@@ -43,7 +68,11 @@ class GeneratorOperatorMixin(OperatorMixin, GeneratorCallbackMixin):
             assert len(args) > 0, (
                 "No data received from upstream. Generator-operator must receive other generators from upstream."
             )
-            output = self.runner(self.__call__, args)
+            args_for_runner, args_for_callbacks = self._tee_upstream_args(args)
+            raw_output = self.runner(self.__call__, args_for_runner)
+            output = self._wrap_streaming_chunk_side_effects(
+                raw_output, args_for_callbacks
+            )
 
             # Callback: After-run
             self._callback_after_run(output)

--- a/miv/core/operator_generator/policy.py
+++ b/miv/core/operator_generator/policy.py
@@ -1,7 +1,10 @@
 __all__ = [
+    "StreamChunkAlignedGeneratorRunner",
     "VanillaGeneratorRunner",
+    "GeneratorRunnerInMultiprocessing",
 ]
 
+from abc import ABC
 from typing import Any, TypeVar, TYPE_CHECKING, Protocol
 from itertools import islice
 import time
@@ -26,7 +29,22 @@ class _LazyCallable(Protocol):
 C = TypeVar("C", bound="GeneratorOperatorMixin")
 
 
-class VanillaGeneratorRunner(RunnerBase):
+class StreamChunkAlignedGeneratorRunner(RunnerBase, ABC):
+    """Base for generator runners that align with *streaming* ``output()`` wrapping.
+
+    :class:`GeneratorOperatorMixin` can interleave **per-chunk** cache writes and
+    generator plot callbacks with the runner by zipping the runner’s generator
+    with the same **tee**’d upstream iterables that the runner consumed. That
+    only works when this runner yields **one** result per row of
+    ``zip(*upstream_iterables)`` in order.
+
+    Subclass this when implementing that contract; use plain :class:`RunnerBase`
+    for other strategies (e.g. batched multiprocessing) until an equivalent
+    wrapper exists.
+    """
+
+
+class VanillaGeneratorRunner(StreamChunkAlignedGeneratorRunner):
     """Default runner for generator operators without any modification.
 
     The operator will be executed in an embarrassingly parallel manner.

--- a/miv/core/operator_generator/wrapper.py
+++ b/miv/core/operator_generator/wrapper.py
@@ -1,9 +1,11 @@
-"""Wrapper decorator for generator operator caching and callbacks."""
+"""Wrapper decorator for generator operators (legacy signature adapter)."""
+
+from __future__ import annotations
 
 import functools
+import warnings
 from typing import Any, TypeVar
 from collections.abc import Callable
-
 
 from .operator import GeneratorOperatorMixin
 
@@ -11,83 +13,37 @@ C = TypeVar("C", bound="GeneratorOperatorMixin")
 
 
 def cache_generator_call(func: Callable) -> Callable:
-    # @functools.wraps(func)
+    """
+    Adapt the generator runner's ``(idx, *chunk_inputs)`` call to ``__call__(*chunk_inputs)``.
+
+    .. deprecated::
+        Per-chunk cache writes and generator plots run from
+        :meth:`~miv.core.operator_generator.operator.GeneratorOperatorMixin.output`.
+        Keep this decorator only while migrating subclasses; it will be removed in
+        a future release.
+
+    A :exc:`DeprecationWarning` is emitted on the **first** call to each wrapped
+    method so importing operators stays quiet until work runs.
+    """
+
+    @functools.wraps(func)
     def wrapper(
         self: C,
         idx: int,
         *args: Any,
         **kwargs: Any,
     ) -> Any:
-        tag = "data"
-        cacher = self.cacher
-        result = func(self, *args, **kwargs)
-        if result is not None:
-            cacher.save_cache(result, idx=idx, tag=tag)
-            if idx == 0:
-                cacher.save_config(tag=tag)  # config saved only once
+        if not getattr(wrapper, "_cg_deprecation_warned", False):  # pragma: no cover
+            warnings.warn(
+                "cache_generator_call is deprecated: GeneratorOperatorMixin.output() "
+                "now applies persist_cacher_result and generator/first-iter plot "
+                "callbacks per chunk. This decorator only strips idx from __call__ "
+                "until subclasses are updated; remove @cache_generator_call when ready.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            wrapper._cg_deprecation_warned = True  # type: ignore[attr-defined]
 
-        # Plotting  # FIXME: Somehow move it in operator mixin?
-        self._callback_generator_plot(idx, result, args, save_path=self.analysis_path)
-        if idx == 0:
-            self._callback_firstiter_plot(result, args, save_path=self.analysis_path)
-
-        return result
+        return func(self, *args, **kwargs)
 
     return wrapper
-
-
-# def cache_generator_call(func: Callable) -> Callable:
-#    """
-#    Cache the methods of the operator.
-#    It is special case for the generator in-out stream.
-#    Save the cache in the cacher object with appropriate tag.
-#
-#    If inputs are not all generators, it will run regular function.
-#    """
-#
-#    def wrapper(
-#        self: C, *args: Any, **kwargs: Any
-#    ) -> Generator | Any | None:
-#        is_all_generator = all(inspect.isgenerator(v) for v in args) and all(
-#            inspect.isgenerator(v) for v in kwargs.values()
-#        )
-#
-#        tag = "data"
-#        cacher = self.cacher
-#
-#        if is_all_generator:
-#
-#            def generator_func(*args: tuple[Generator, ...]) -> Generator:
-#                for idx, zip_arg in enumerate(zip(*args, strict=False)):
-#                    stime = time.time()
-#                    result = func(self, *zip_arg, **kwargs)
-#                    # print(f"    iter {idx:03d} {self}: {time.time() - stime:.03f}sec", flush=True)
-#                    if result is not None:
-#                        # In case the module does not return anything
-#                        cacher.save_cache(result, idx, tag=tag)
-#                    self._callback_generator_plot(
-#                        idx, result, zip_arg, save_path=self.analysis_path
-#                    )
-#                    if idx == 0:
-#                        self._callback_firstiter_plot(
-#                            result, zip_arg, save_path=self.analysis_path
-#                        )
-#                    yield result
-#                cacher.save_config(tag=tag)
-#                # TODO: add lastiter_plot
-#                # FIXME
-#                self._done_flag_generator_plot = True
-#                self._done_flag_firstiter_plot = True
-#
-#            generator = generator_func(*args, *kwargs.values())
-#            return generator
-#        else:
-#            result = func(self, *args, **kwargs)
-#            if result is None:
-#                # In case the module does not return anything
-#                return None
-#            cacher.save_cache(result, tag=tag)
-#            cacher.save_config(tag=tag)
-#            return result
-#
-#    return wrapper

--- a/tests/core/test_cache_write.py
+++ b/tests/core/test_cache_write.py
@@ -1,0 +1,69 @@
+"""Tests for :mod:`miv.core.cache_write` (shared persist rules for cachers)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from miv.core.cachable import CACHE_POLICY
+from miv.core.cache_write import persist_cacher_result
+
+
+class RecordingCacher:
+    """Minimal cacher that records save_cache / save_config invocations."""
+
+    def __init__(self) -> None:
+        self.policy: CACHE_POLICY = "ON"
+        self.cache_dir: str = "."
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def save_cache(self, value: Any, idx: int = 0, tag: str = "data") -> bool:
+        self.calls.append(("save_cache", (value, idx, tag), {}))
+        return True
+
+    def save_config(
+        self, tag: str = "data", *args: Any, **kwargs: Any
+    ) -> bool:
+        self.calls.append(("save_config", (tag,), dict(kwargs)))
+        return True
+
+
+def test_persist_first_chunk_saves_cache_and_config() -> None:
+    """Same rules as scalar ``output()``: index 0 writes data and config."""
+    c = RecordingCacher()
+    persist_cacher_result(c, 42, chunk_index=0, tag="data")
+    assert c.calls == [
+        ("save_cache", (42, 0, "data"), {}),
+        ("save_config", ("data",), {}),
+    ]
+
+
+def test_persist_later_chunk_saves_cache_only() -> None:
+    """Generator paths: only chunk 0 triggers ``save_config`` (config once)."""
+    c = RecordingCacher()
+    persist_cacher_result(c, "b", chunk_index=2, tag="data")
+    assert c.calls == [("save_cache", ("b", 2, "data"), {})]
+
+
+def test_persist_none_is_noop() -> None:
+    c = RecordingCacher()
+    persist_cacher_result(c, None)
+    assert c.calls == []
+
+
+def test_persist_forwards_save_config_kwargs_on_first_chunk_only() -> None:
+    """Source-style :class:`~miv.core.source.cachable.FunctionalCacher` uses ``params`` for config."""
+    c = RecordingCacher()
+    params = ((), {"x": 1})
+    persist_cacher_result(
+        c, "payload", chunk_index=0, tag="data", params=params
+    )
+    assert c.calls == [
+        ("save_cache", ("payload", 0, "data"), {}),
+        ("save_config", ("data",), {"params": params}),
+    ]
+
+    c2 = RecordingCacher()
+    persist_cacher_result(
+        c2, "chunk", chunk_index=3, tag="data", params=params
+    )
+    assert c2.calls == [("save_cache", ("chunk", 3, "data"), {})]

--- a/tests/core/test_wrappers.py
+++ b/tests/core/test_wrappers.py
@@ -4,6 +4,11 @@ from miv.core.operator.wrapper import cache_call
 from miv.core.source.wrapper import cached_method
 from miv.core.operator_generator.wrapper import cache_generator_call
 
+# Decorator warnings at @apply time when tests define wrapped helpers
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:cache_generator_call is deprecated:DeprecationWarning:miv.core.operator_generator.wrapper"
+)
+
 
 class GeneratorPlotMixin:
     # TODO: This is a temporary solution to avoid issue. calling generator_plot in wrapper should be reconsidered
@@ -137,25 +142,21 @@ class FooClassV2(MockObjectWithCache):
 
 
 def test_wrap_generator_cache(mock_object_with_cache, tmp_path):
+    """
+    Direct calls to a @cache_generator_call user method no longer write through
+    cacher; streaming persist runs from GeneratorOperatorMixin.output() (see
+    test_generator_operator_caching).
+    """
     @cache_generator_call
     def foo(self, x, y):
         return x + y
 
-    def bar():
-        yield 1
-        yield 2
-        yield 3
-
     idx = 0
     assert foo(mock_object_with_cache, idx, 3, 4) == 7
-    for v in mock_object_with_cache.cacher.load_cached():
-        assert v == 0  # mock cache only saves zero. (above)
 
-    # Test cache_generator_call
+    # Test cache_generator_call adapter only (idx stripped from __call__)
     a = FooClassV2(tmp_path)
     assert a(idx, 12, 13) == 25
-    for v in a.cacher.load_cached():
-        assert v == 0  # mock cache only saves zero. (above)
 
     # Test cached_method
     a = FooClassV2(tmp_path)


### PR DESCRIPTION
## Summary

Introduces `miv.core.cache_write.persist_cacher_result` as a single shared function governing when `save_cache` and `save_config` are called relative to chunk index. Scalar operators (`OperatorMixin`) and streaming operators (`GeneratorOperatorMixin`) now both route through this function, eliminating the duplicated inline logic that previously existed in each path.

For generator operators, per-chunk cache writes and generator/first-iteration plot callbacks are now driven directly from `GeneratorOperatorMixin.output()` via `_wrap_streaming_chunk_side_effects`, which zips the runner's output against tee'd upstream iterables. A new `StreamChunkAlignedGeneratorRunner` ABC marks runners that satisfy the one-result-per-upstream-row contract required by this wrapping strategy.

`cache_generator_call` is deprecated to a thin signature adapter that strips the `idx` argument before forwarding to `__call__`. It emits a `DeprecationWarning` on first use and no longer performs any cache writes or plot callbacks itself.

Fixes # (issue)

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation

## Testing

- [x] Tests added/updated

`tests/core/test_cache_write.py` covers `persist_cacher_result` for first-chunk (cache + config), later chunks (cache only), `None` no-op, and forwarding of `save_config` kwargs. `tests/core/test_wrappers.py` is updated to suppress the deprecation warning and removes assertions that relied on the decorator writing through the cacher.

## Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed
- [x] Tests pass locally