### PR TITLE
Refactor protocol imports and enhance _Node definition:

### DIFF
--- a/miv/core/operator/operator.py
+++ b/miv/core/operator/operator.py
@@ -18,13 +18,8 @@ from .cachable import DataclassCacher
 from .callback import BaseCallbackMixin
 from .policy import VanillaRunner, RunnerBase
 
-if TYPE_CHECKING:
-    from ..datatype import DataTypes
-    from .protocol import _Node
-
-else:
-
-    class _Node: ...
+from ..datatype import DataTypes
+from ..protocol import _Node
 
 
 class OperatorMixin(ChainingMixin, BaseCallbackMixin, DefaultLoggerMixin):
@@ -47,7 +42,7 @@ class OperatorMixin(ChainingMixin, BaseCallbackMixin, DefaultLoggerMixin):
 
         super().__init__(*args, cacher=DataclassCacher(self), **kwargs)
 
-        # Attribute from upstream
+        # Attribute from parent
         self.tag: str
 
     @abstractmethod

--- a/miv/core/operator/protocol.py
+++ b/miv/core/operator/protocol.py
@@ -3,13 +3,11 @@ Specification of the behaviors for Operator modules.
 """
 
 from typing import Protocol, Any
-
-import pathlib
 from abc import abstractmethod
 
 from .policy import RunnerBase
-from ..protocol import _Loggable, _Chainable, _Cachable
-from ..datatype import DataTypes
+
+__all__ = ["_Runnable"]
 
 
 class _Runnable(Protocol):
@@ -24,25 +22,3 @@ class _Runnable(Protocol):
 
     @abstractmethod
     def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
-
-
-class _Node(
-    _Loggable,
-    _Runnable,
-    _Chainable,
-    _Cachable,
-    Protocol,
-):
-    """
-    Protocol defining the complete behavior of an Operator node.
-    Each protocol aspect is separately defined to allow for cleaner composition.
-    """
-
-    analysis_path: str
-
-    def output(self) -> DataTypes: ...
-    def set_save_path(
-        self,
-        path: str | pathlib.Path,
-        cache_path: str | pathlib.Path | None = None,
-    ) -> None: ...

--- a/miv/core/operator_generator/callback.py
+++ b/miv/core/operator_generator/callback.py
@@ -20,28 +20,6 @@ if TYPE_CHECKING:
     from miv.core.datatype import DataTypes
 
 
-class _GeneratorCallback(Protocol):
-    _done_flag_generator_plot: bool
-    _done_flag_firstiter_plot: bool
-
-    def _callback_generator_plot(
-        self,
-        iter_index: int,
-        output: "DataTypes",
-        inputs: tuple["DataTypes", ...] | None = None,
-        show: bool = False,
-        save_path: str | pathlib.Path | None = None,
-    ) -> None: ...
-
-    def _callback_firstiter_plot(
-        self,
-        output: "DataTypes",
-        inputs: tuple["DataTypes", ...] | None = None,
-        show: bool = False,
-        save_path: str | pathlib.Path | None = None,
-    ) -> None: ...
-
-
 class GeneratorCallbackMixin(DefaultLoggerMixin):
     """
     Additional methods for generator-to-generator operator.

--- a/miv/core/operator_generator/operator.py
+++ b/miv/core/operator_generator/operator.py
@@ -73,10 +73,5 @@ class GeneratorOperatorMixin(OperatorMixin, GeneratorCallbackMixin):
             output = self._wrap_streaming_chunk_side_effects(
                 raw_output, args_for_callbacks
             )
-
-            # Callback: After-run
-            self._callback_after_run(output)
-
-            # Plotting: Only happened when cache is not called
-            self._callback_plot(output, args, show=False)
+            # after_run / plot_* run per chunk inside _wrap_streaming_chunk_side_effects
         return output

--- a/miv/core/pipeline.py
+++ b/miv/core/pipeline.py
@@ -16,7 +16,7 @@ import sys
 from loguru import logger
 
 from ..utils.formatter import TColors
-from .operator.protocol import _Node
+from .protocol import _Node
 from .utils.graph_sorting import topological_sort
 from .loggable import configure_logger
 

--- a/miv/core/protocol.py
+++ b/miv/core/protocol.py
@@ -5,7 +5,7 @@ This module includes a basic core protocols used in many place throughout.
 the library. For specific behaviors, protocols will be specified in the
 module/protocol.py files.
 """
-__all__ = ["_Loggable"]
+__all__ = ["_Loggable", "_Node"]
 
 from collections.abc import Iterator
 from typing import Any, Protocol, TypeVar
@@ -17,6 +17,8 @@ from .cachable import _CacherProtocol, CACHE_POLICY
 class _Cachable(Protocol):
     """
     A protocol for cachable behavior.
+
+    The node is cachable, simply if it has a cacher.
     """
 
     cacher: _CacherProtocol
@@ -64,3 +66,16 @@ class _Chainable(Protocol[C]):
     def iterate_downstream(self) -> Iterator[C]: ...
 
     def flow_blocked(self) -> bool: ...
+
+
+class _Node(_Chainable[Any], Protocol):
+    """
+    Minimal graph vertex the pipeline can schedule and execute.
+
+    Matches :func:`miv.core.utils.graph_sorting.topological_sort` (chainable +
+    ``flow_blocked``) and :meth:`miv.core.pipeline.Pipeline.run` (``output`` on
+    sink nodes). Optional hooks like ``set_save_path`` / ``reset_callbacks`` are
+    duck-typed at runtime and are not part of this protocol.
+    """
+
+    def output(self) -> Any: ...


### PR DESCRIPTION
## Summary

Moves the `_Node` protocol definition from `miv/core/operator/protocol.py` into the top-level `miv/core/protocol.py`, consolidating it alongside other core protocols (`_Loggable`, `_Chainable`, `_Cachable`). The `_Node` protocol is now defined as a minimal `_Chainable` subtype with an `output()` method, removing the previously broader definition that included `_Loggable`, `_Runnable`, and `_Cachable`. Imports across `pipeline.py` and `operator.py` are updated to reference the new location. The unused `_GeneratorCallback` protocol and the duplicate `_Node` class stub in `operator.py` are also removed, along with redundant per-chunk callback calls in the generator operator that are already handled inside `_wrap_streaming_chunk_side_effects`.

Fixes # (issue)

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation

## Testing

- [ ] Tests added/updated

## Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed
- [x] Tests pass locally