### PR TITLE
Refactor operator mixins and enhance chaining functionality:

### DIFF
--- a/miv/core/chainable.py
+++ b/miv/core/chainable.py
@@ -5,7 +5,7 @@ Mixin to create chaining structure between objects.
 """
 __all__ = ["ChainingMixin", "node_graph_visualize"]
 
-from typing import TYPE_CHECKING, Any, TypeVar, Generic
+from typing import TYPE_CHECKING, Any, TypeVar, Generic, cast
 from collections.abc import Iterator
 from collections import deque
 from abc import ABC, abstractmethod
@@ -14,6 +14,7 @@ import itertools
 
 import matplotlib.pyplot as plt
 
+from .protocol import _Node
 
 if TYPE_CHECKING:
     import networkx as nx
@@ -26,7 +27,10 @@ class ChainingMixin(ABC, Generic[C]):
     """
     Base mixin to create chaining structure between objects.
 
-    Need further implementation of: output, tag
+    Subclasses must implement :meth:`flow_blocked`, and provide ``output`` /
+    ``tag`` as needed for their role in the graph.
+
+    :meth:`receive` returns each upstream node's ``output()`` in link order.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -76,6 +80,10 @@ class ChainingMixin(ABC, Generic[C]):
         Returns:
             True if flow is blocked, False otherwise.
         """
+
+    def receive(self) -> list[Any]:
+        """Return each upstream node's ``output()`` in upstream list order."""
+        return [cast(_Node, node).output() for node in self.iterate_upstream()]
 
     def visualize(self, ax: plt.Axes, seed: int = 200) -> nx.DiGraph:
         """

--- a/miv/core/operator/operator.py
+++ b/miv/core/operator/operator.py
@@ -5,24 +5,21 @@ Here, we define the behavior of basic operator class, and useful mixin classes t
 be used to create new operators that conform to required behaviors.
 """
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 from abc import abstractmethod
 
 import pathlib
 
-from loguru import logger
 from ..chainable import ChainingMixin
-from ..loggable import DefaultLoggerMixin
 from ..cache_write import persist_cacher_result
 from .cachable import DataclassCacher
 from .callback import BaseCallbackMixin
 from .policy import VanillaRunner, RunnerBase
 
 from ..datatype import DataTypes
-from ..protocol import _Node
 
 
-class OperatorMixin(ChainingMixin, BaseCallbackMixin, DefaultLoggerMixin):
+class OperatorMixin(ChainingMixin, BaseCallbackMixin):
     """
     Behavior includes:
         - Whenever "run()" method is executed:
@@ -45,32 +42,21 @@ class OperatorMixin(ChainingMixin, BaseCallbackMixin, DefaultLoggerMixin):
         # Attribute from parent
         self.tag: str
 
-    @abstractmethod
-    def __call__(self) -> DataTypes:
-        """Execute the operator. Must be implemented by subclasses."""
-
     def __repr__(self) -> str:
         return self.tag
 
     def __str__(self) -> str:
         return self.tag
 
-    def receive(self) -> list[DataTypes]:
-        """
-        Receive input data from each upstream operator.
-        Essentially, this method recursively call upstream operators' run() method.
-        """
-        ret = []
-        for node in self.iterate_upstream():
-            output = cast(_Node, node).output()
-            ret.append(output)
-        return ret
-
     def flow_blocked(self) -> bool:
         try:
             return self.cacher.check_cached(skip_log=True)
         except (AttributeError, FileNotFoundError):
             return False
+
+    @abstractmethod
+    def __call__(self) -> DataTypes:
+        """Execute the operator. Must be implemented by subclasses."""
 
     def output(self) -> DataTypes:
         """

--- a/miv/core/operator_generator/callback.py
+++ b/miv/core/operator_generator/callback.py
@@ -4,14 +4,14 @@ This module provides callback functionality for generator-to-generator operators
 including plotting callbacks that execute during generator iterations.
 """
 
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 import pathlib
 
 import matplotlib.pyplot as plt
 
-from ..loggable import DefaultLoggerMixin
 from ..operator.callback import (
+    BaseCallbackMixin,
     get_methods_from_feature_classes_by_startswith_str,
     execute_callback,
 )
@@ -20,16 +20,16 @@ if TYPE_CHECKING:
     from miv.core.datatype import DataTypes
 
 
-class GeneratorCallbackMixin(DefaultLoggerMixin):
+class GeneratorCallbackMixin(BaseCallbackMixin):
     """
-    Additional methods for generator-to-generator operator.
+    Callback stack for generator-to-generator operators (extends scalar operator callbacks).
 
     `generator_plot` method plots during each iteration of generator.
     The function take `show` and `save_path` arguments similar to `plot` method.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
 
         self._done_flag_generator_plot = False
         self._done_flag_firstiter_plot = False

--- a/miv/core/operator_generator/operator.py
+++ b/miv/core/operator_generator/operator.py
@@ -5,22 +5,34 @@ from typing import Any
 from collections.abc import Generator, Iterable
 
 from ..cache_write import persist_cacher_result
-from ..cachable import CACHE_POLICY
-from ..operator.operator import OperatorMixin
-from .callback import (
-    GeneratorCallbackMixin,
-)
+from ..chainable import ChainingMixin
+from ..operator.cachable import DataclassCacher
+from ..operator.policy import RunnerBase, VanillaRunner
+from .callback import GeneratorCallbackMixin
 from .policy import StreamChunkAlignedGeneratorRunner, VanillaGeneratorRunner
 
 
-class GeneratorOperatorMixin(OperatorMixin, GeneratorCallbackMixin):
-    def __init__(self) -> None:
-        super().__init__()
+class GeneratorOperatorMixin(ChainingMixin, GeneratorCallbackMixin):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.runner: RunnerBase = VanillaRunner()
+        self.analysis_path = "analysis"
 
-        self.runner: StreamChunkAlignedGeneratorRunner = VanillaGeneratorRunner(self)
+        super().__init__(*args, cacher=DataclassCacher(self), **kwargs)
 
-    def set_caching_policy(self, policy: CACHE_POLICY) -> None:
-        self.cacher.policy = policy
+        self.tag: str
+        self.runner = VanillaGeneratorRunner(self)
+
+    def __repr__(self) -> str:
+        return self.tag
+
+    def __str__(self) -> str:
+        return self.tag
+
+    def flow_blocked(self) -> bool:
+        try:
+            return self.cacher.check_cached(skip_log=True)
+        except (AttributeError, FileNotFoundError):
+            return False
 
     @staticmethod
     def _tee_upstream_args(

--- a/tests/core/mock_chain.py
+++ b/tests/core/mock_chain.py
@@ -1,4 +1,4 @@
-from miv.core.operator.operator import ChainingMixin
+from miv.core.chainable import ChainingMixin
 from tests.core.mock_runner import MockRunner
 
 


### PR DESCRIPTION
## Summary

Moves the `receive()` method from `OperatorMixin` into `ChainingMixin` as a shared base implementation, making it available to all chaining nodes rather than only scalar operators. `GeneratorOperatorMixin` is refactored to inherit directly from `ChainingMixin` and `GeneratorCallbackMixin` instead of going through `OperatorMixin`, giving it its own `flow_blocked`, `__repr__`, and `__str__` implementations. `GeneratorCallbackMixin` now extends `BaseCallbackMixin` instead of `DefaultLoggerMixin`. Unused imports of `DefaultLoggerMixin`, `_Node`, and `logger` are removed from the operator and generator modules.

Fixes # (issue)

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation

## Testing

- [x] Tests added/updated

## Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed
- [x] Tests pass locally