### PR TITLE
Implement callback enhancements and refactor callback mixins:

### DIFF
--- a/docs/tutorial/core_concept.md
+++ b/docs/tutorial/core_concept.md
@@ -75,7 +75,7 @@ This creates a dependency graph where `operator1` is upstream of `operator2`, et
 **Callbacks**: Support for custom callbacks:
 
 - `after_run_*`: Methods called after operator execution
-- `plot_*`: Methods called for visualization (can be skipped with `skip_plot=True`)
+- `plot_*`: Methods called for visualization (can be skipped with `skip_plot=True` passed to `Pipeline`)
 - Callbacks can be dynamically added using the `<<` operator
 
 **Runner Policies**: Different execution strategies for parallelization:

--- a/docs/tutorial/core_concept.md
+++ b/docs/tutorial/core_concept.md
@@ -78,6 +78,39 @@ This creates a dependency graph where `operator1` is upstream of `operator2`, et
 - `plot_*`: Methods called for visualization (can be skipped with `skip_plot=True` passed to `Pipeline`)
 - Callbacks can be dynamically added using the `<<` operator
 
+#### Adding callbacks: `OperatorMixin` vs `OperatorGeneratorMixin`
+
+Use callback name prefixes to register post-processing hooks:
+
+- `OperatorMixin` (scalar output):
+  - `after_run_*` receives the operator output.
+  - `plot_*` receives `(output, inputs, show=False, save_path=None)`.
+- `OperatorGeneratorMixin` (streaming output):
+  - `generator_plot_*` runs for each yielded chunk and receives
+    `(output, inputs, show=False, save_path=None, index=<iter>)`.
+  - `firstiter_plot_*` runs on the first yielded chunk and receives
+    `(output, inputs, show=False, save_path=None)`.
+
+```python
+# Scalar operator callbacks
+class MyScalarOp(...):
+    def after_run_report(self, output):
+        ...
+
+    def plot_summary(self, output, inputs, show=False, save_path=None):
+        ...
+
+# Generator operator callbacks
+class MyGeneratorOp(...):
+    def generator_plot_trace(self, output, inputs, show=False, save_path=None, index=0):
+        ...
+
+    def firstiter_plot_preview(self, output, inputs, show=False, save_path=None):
+        ...
+```
+
+You can also attach external functions with `<<`; naming still controls when they run.
+
 **Runner Policies**: Different execution strategies for parallelization:
 
 - `VanillaRunner`: Default sequential execution (supports MPI broadcast if available)

--- a/miv/core/callback.py
+++ b/miv/core/callback.py
@@ -1,0 +1,179 @@
+"""Shared callback utilities and :class:`BaseCallbackMixin` for pipeline nodes.
+
+Scalar hooks (``after_run``, ``plot_``) live in :mod:`miv.core.operator.callback`
+(:class:`ScalarCallbackMixin`). Streaming plot hooks live in
+:mod:`miv.core.operator_generator.callback` (:class:`GeneratorCallbackMixin`).
+"""
+
+from __future__ import annotations
+
+__all__ = ["BaseCallbackMixin"]
+
+from typing import Any, ClassVar
+from collections.abc import Callable
+from typing_extensions import Self
+
+import types
+import inspect
+import os
+import pathlib
+
+import matplotlib.pyplot as plt
+
+from .loggable import DefaultLoggerMixin
+from .cachable import _CacherProtocol, CACHE_POLICY
+
+
+def execute_callback(
+    logger: Any,
+    callback: Callable,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    """Execute one callback and swallow/log any exception."""
+    try:
+        callback(*args, **kwargs)
+    except Exception:
+        logger.exception(
+            "There was an issue running the following callback. (No exception will be raised during callback.)"
+        )
+
+
+def get_methods_from_feature_classes_by_startswith_str(
+    cls: Any, method_name: str
+) -> list[Callable]:
+    """Return callable attributes on ``cls`` whose names start with ``method_name``."""
+    methods = [
+        getattr(cls, k)
+        for k in dir(cls)
+        if k.startswith(method_name) and callable(getattr(cls, k))
+    ]
+    return methods
+
+
+def get_methods_from_feature_classes_by_endswith_str(
+    cls: Any, method_name: str
+) -> list[Callable]:
+    """Return callable attributes on ``cls`` whose names end with ``method_name``."""
+    methods = [
+        getattr(cls, k)
+        for k in dir(cls)
+        if k.endswith(method_name) and callable(getattr(cls, k))
+    ]
+    return methods
+
+
+def invoke_prefixed_callbacks(
+    target: Any,
+    logger: Any,
+    name_prefix: str,
+    *call_args: Any,
+    **call_kwargs: Any,
+) -> None:
+    """Invoke all ``target`` callbacks that match ``name_prefix``."""
+    for fn in get_methods_from_feature_classes_by_startswith_str(target, name_prefix):
+        execute_callback(logger, fn, *call_args, **call_kwargs)
+
+
+class BaseCallbackMixin(DefaultLoggerMixin):
+    """Cacher, paths, ``<<`` attachment, and generic :meth:`_callback` dispatch.
+
+    Subclasses set :attr:`_callback_group_names` and
+    :attr:`_callback_group_argument_transforms` for the groups they support.
+
+    Extension note:
+    This callback system is intentionally strict and currently optimized for two
+    extension families (scalar and generator callbacks), which keeps the design
+    easy to reason about for this codebase. When adding new callback groups,
+    update both the group-name and argument-transform mappings together.
+    Future refactors may introduce a more ergonomic extension surface if the
+    number of callback families grows.
+    """
+
+    _callback_group_names: ClassVar[tuple[str, ...]] = ()
+    _callback_group_argument_transforms: ClassVar[dict[str, Callable]] = {}
+
+    def __init__(
+        self,
+        *args: Any,
+        cacher: _CacherProtocol,
+        cache_path: str = ".cache",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.__cache_directory_name: str = cache_path
+        self._cacher: _CacherProtocol = cacher
+
+        assert self.tag != "", (
+            "All operator must have self.tag attribute for identification."
+        )
+
+        self._callback_done = dict.fromkeys(self._callback_group_names, False)
+
+        self.tag: str
+
+    @property
+    def cacher(self) -> _CacherProtocol:
+        return self._cacher
+
+    @cacher.setter
+    def cacher(self, value: _CacherProtocol) -> None:
+        policy = self._cacher.policy
+        cache_dir = self._cacher.cache_dir
+        self._cacher = value
+        self._cacher.policy = policy
+        self._cacher.cache_dir = cache_dir
+
+    def set_caching_policy(self, policy: CACHE_POLICY) -> None:
+        """Set cache read/write policy on the underlying cacher."""
+        self.cacher.policy = policy
+
+    def set_callback_done(self, name: str, done: bool) -> None:
+        """Set callback done-flag; unknown groups are ignored."""
+        if name not in self._callback_done:
+            return
+        self._callback_done[name] = done
+
+    def __lshift__(self, right: Callable) -> Self:
+        """Attach a callback function to this instance (bound when ``self`` arg exists)."""
+        if inspect.getfullargspec(right)[0][0] == "self":
+            setattr(self, right.__name__, types.MethodType(right, self))
+        else:
+            setattr(self, right.__name__, right)
+        return self
+
+    def set_save_path(
+        self,
+        path: str | pathlib.Path,
+        cache_path: str | pathlib.Path | None = None,
+    ) -> None:
+        """Configure analysis/cache directories for this node instance."""
+        if cache_path is None:
+            cache_path = path
+
+        self.analysis_path = os.path.join(path, self.tag.replace(" ", "_"))
+        _cache_path = os.path.join(
+            cache_path, self.tag.replace(" ", "_"), self.__cache_directory_name
+        )
+        self.cacher.cache_dir = _cache_path
+
+        os.makedirs(self.analysis_path, exist_ok=True)
+
+    def _callback(
+        self, callback_name: str, *args: Any, set_done: bool = True, **kwargs: Any
+    ) -> None:
+        """Dispatch one callback group by prefix using the configured argument transform."""
+        if self._callback_done.get(callback_name, False):
+            return
+        prefix = f"{callback_name}_"
+        prepare_fn = self._callback_group_argument_transforms[callback_name]
+
+        call_args, call_kwargs = prepare_fn(self, args, kwargs)
+        invoke_prefixed_callbacks(self, self.logger, prefix, *call_args, **call_kwargs)
+
+        # TODO: Not sure if this is still needed
+        if kwargs.get("show", False):
+            plt.show()
+        plt.close("all")
+
+        self._callback_done[callback_name] = set_done

--- a/miv/core/datatype/pure_python.py
+++ b/miv/core/datatype/pure_python.py
@@ -61,6 +61,7 @@ class GeneratorType(ChainingMixin):
     def output(self) -> Generator:
         yield from self.iterator
 
+    # Deprecated
     def run(self, **kwargs: Any) -> Generator:
         yield from self.output()
 

--- a/miv/core/operator/callback.py
+++ b/miv/core/operator/callback.py
@@ -1,178 +1,37 @@
-__doc__ = """
-Implementation for callback features that will be mixed in operator class.
-"""
-__all__ = ["BaseCallbackMixin"]
+"""Scalar-operator callback groups (``after_run``, ``plot_``)."""
 
-from typing import Any
-from collections.abc import Callable
-from typing_extensions import Self
+from __future__ import annotations
 
-import types
-import inspect
-import os
-import pathlib
-import logging
+from typing import Any, ClassVar
 
-import matplotlib.pyplot as plt
-
-from ..loggable import DefaultLoggerMixin
-from ..cachable import _CacherProtocol, CACHE_POLICY
+from ..callback import BaseCallbackMixin
 
 
-def execute_callback(
-    logger: logging.Logger, callback: Callable, *args: Any, **kwargs: Any
-) -> None:
-    """
-    Executes a callback function with optional args/kwargs.
-    Logs a warning if an exception occurs.
-    """
-    try:
-        callback(*args, **kwargs)
-    except Exception:
-        logger.exception(
-            "There was an issue running the following callback. (No exception will be raised during callback.)"
-        )
+def _prepare_after_run_local(
+    _self: Any, args: tuple[Any, ...], kw: dict[str, Any]
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    return args, kw
 
 
-# MixinOperators
-def get_methods_from_feature_classes_by_startswith_str(
-    cls: Any, method_name: str
-) -> list[Callable]:
-    methods = [
-        getattr(cls, k)
-        for k in dir(cls)
-        if k.startswith(method_name) and callable(getattr(cls, k))
-    ]
-    return methods
+def _prepare_plot_local(
+    self: Any, args: tuple[Any, ...], kw: dict[str, Any]
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    output = args[0] if args else None
+    inputs = args[1] if len(args) > 1 else None
+    show = kw.get("show", False)
+    save_path = kw.get("save_path")
+    if save_path is None:
+        save_path = self.analysis_path
+    if isinstance(inputs, list) and len(inputs) == 1:
+        inputs = inputs[0]
+    return (output, inputs), {"show": show, "save_path": save_path}
 
 
-# MixinOperators
-def get_methods_from_feature_classes_by_endswith_str(
-    cls: Any, method_name: str
-) -> list[Callable]:
-    methods = [
-        getattr(cls, k)
-        for k in dir(cls)
-        if k.endswith(method_name) and callable(getattr(cls, k))
-    ]
-    return methods
+class ScalarCallbackMixin(BaseCallbackMixin):
+    """Mixin for scalar operators: ``after_run`` + ``plot`` hook groups."""
 
-
-class BaseCallbackMixin(DefaultLoggerMixin):
-    def __init__(
-        self,
-        *args: Any,
-        cacher: _CacherProtocol,
-        cache_path: str = ".cache",
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.__cache_directory_name: str = cache_path
-        self._cacher: _CacherProtocol = cacher
-        self.skip_plot: bool = False
-
-        # Default analysis path
-        assert self.tag != "", (
-            "All operator must have self.tag attribute for identification."
-        )
-        # self.set_save_path("results")  # FIXME
-
-        # Callback Flags (to avoid duplicated run)
-        self._done_flag_after_run = False
-        self._done_flag_plot = False
-
-        # Attribute from upstream
-        self.tag: str
-
-    @property
-    def cacher(self) -> _CacherProtocol:
-        return self._cacher
-
-    @cacher.setter
-    def cacher(self, value: _CacherProtocol) -> None:
-        # FIXME:
-        policy = self._cacher.policy
-        cache_dir = self._cacher.cache_dir
-        self._cacher = value
-        self._cacher.policy = policy
-        self._cacher.cache_dir = cache_dir
-
-    def set_caching_policy(self, policy: CACHE_POLICY) -> None:
-        self.cacher.policy = policy
-
-    def reset_callbacks(self, *, after_run: bool = False, plot: bool = False) -> None:
-        self._done_flag_after_run = after_run
-        self._done_flag_plot = plot
-
-    def __lshift__(self, right: Callable) -> Self:
-        # Dynamically add new function into an operator instance
-        if inspect.getfullargspec(right)[0][0] == "self":
-            setattr(self, right.__name__, types.MethodType(right, self))
-        else:
-            # Add new function into as attribute
-            setattr(self, right.__name__, right)
-        return self
-
-    def set_save_path(
-        self,
-        path: str | pathlib.Path,
-        cache_path: str | pathlib.Path | None = None,
-    ) -> None:
-        if cache_path is None:
-            cache_path = path
-
-        # Set analysis path
-        self.analysis_path = os.path.join(path, self.tag.replace(" ", "_"))
-        # Set cache path
-        _cache_path = os.path.join(
-            cache_path, self.tag.replace(" ", "_"), self.__cache_directory_name
-        )
-        self.cacher.cache_dir = _cache_path
-
-        # Make directory  # Not sure if this needs to be done here
-        os.makedirs(self.analysis_path, exist_ok=True)
-
-    def _callback_after_run(self, *args: Any, **kwargs: Any) -> None:
-        if self._done_flag_after_run:
-            return
-
-        predefined_callbacks = get_methods_from_feature_classes_by_startswith_str(
-            self, "after_run"
-        )
-        for callback in predefined_callbacks:
-            execute_callback(self.logger, callback, *args, **kwargs)
-
-        self._done_flag_after_run = True
-
-    def _callback_plot(
-        self,
-        output: Any | None,
-        inputs: list | None = None,
-        show: bool = False,
-        save_path: str | pathlib.Path | None = None,
-    ) -> None:
-        """
-        Run all function in this operator that starts with the name 'plot_'.
-        """
-        if self.skip_plot:
-            return
-
-        if self._done_flag_plot:
-            return
-
-        if save_path is None:
-            save_path = self.analysis_path
-
-        # If input is single-argument, strip the list
-        if isinstance(inputs, list) and len(inputs) == 1:
-            inputs = inputs[0]
-
-        plotters = get_methods_from_feature_classes_by_startswith_str(self, "plot_")
-        for plotter in plotters:
-            execute_callback(
-                self.logger, plotter, output, inputs, show=show, save_path=save_path
-            )
-        if not show:
-            plt.close("all")
-
-        self._done_flag_plot = True
+    _callback_group_names: ClassVar[tuple[str, ...]] = ("after_run", "plot")
+    _callback_group_argument_transforms = {
+        "after_run": _prepare_after_run_local,
+        "plot": _prepare_plot_local,
+    }

--- a/miv/core/operator/operator.py
+++ b/miv/core/operator/operator.py
@@ -13,13 +13,13 @@ import pathlib
 from ..chainable import ChainingMixin
 from ..cache_write import persist_cacher_result
 from .cachable import DataclassCacher
-from .callback import BaseCallbackMixin
+from .callback import ScalarCallbackMixin
 from .policy import VanillaRunner, RunnerBase
 
 from ..datatype import DataTypes
 
 
-class OperatorMixin(ChainingMixin, BaseCallbackMixin):
+class OperatorMixin(ChainingMixin, ScalarCallbackMixin):
     """
     Behavior includes:
         - Whenever "run()" method is executed:
@@ -82,10 +82,10 @@ class OperatorMixin(ChainingMixin, BaseCallbackMixin):
             persist_cacher_result(self.cacher, output, tag="data")
 
             # Callback: After-run
-            self._callback_after_run(output)
+            self._callback("after_run", output)
 
             # Plotting: Only happened when cache is not called
-            self._callback_plot(output, args, show=False)
+            self._callback("plot", output, args, show=False)
 
         return output
 
@@ -106,5 +106,5 @@ class OperatorMixin(ChainingMixin, BaseCallbackMixin):
 
         # Plotting: Only happened when cache is not called
         args = self.receive()  # Receive data from upstream
-        self._done_flag_plot = False  # FIXME
-        self._callback_plot(output, args, show=show, save_path=save_path)
+        self.set_callback_done("plot", False)  # FIXME
+        self._callback("plot", output, args, show=show, save_path=save_path)

--- a/miv/core/operator_generator/callback.py
+++ b/miv/core/operator_generator/callback.py
@@ -4,95 +4,51 @@ This module provides callback functionality for generator-to-generator operators
 including plotting callbacks that execute during generator iterations.
 """
 
-from typing import TYPE_CHECKING, Any
+from __future__ import annotations
 
-import pathlib
+from typing import Any, ClassVar
 
-import matplotlib.pyplot as plt
+from ..callback import BaseCallbackMixin
 
-from ..operator.callback import (
-    BaseCallbackMixin,
-    get_methods_from_feature_classes_by_startswith_str,
-    execute_callback,
-)
 
-if TYPE_CHECKING:
-    from miv.core.datatype import DataTypes
+def _prepare_generator_plot_local(
+    _self: Any, args: tuple[Any, ...], kw: dict[str, Any]
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    iter_index = args[0]
+    output = args[1] if len(args) > 1 else None
+    inputs = args[2] if len(args) > 2 else None
+    show = kw.get("show", False)
+    save_path = kw.get("save_path")
+    return (output, inputs), {
+        "show": show,
+        "save_path": save_path,
+        "index": iter_index,
+    }
+
+
+def _prepare_firstiter_plot_local(
+    _self: Any, args: tuple[Any, ...], kw: dict[str, Any]
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    output = args[0] if args else None
+    inputs = args[1] if len(args) > 1 else None
+    show = kw.get("show", False)
+    save_path = kw.get("save_path")
+    return (output, inputs), {"show": show, "save_path": save_path}
 
 
 class GeneratorCallbackMixin(BaseCallbackMixin):
     """
-    Callback stack for generator-to-generator operators (extends scalar operator callbacks).
+    Streaming plot hook groups: ``generator_plot``, ``firstiter_plot``.
 
-    `generator_plot` method plots during each iteration of generator.
-    The function take `show` and `save_path` arguments similar to `plot` method.
+    Call :meth:`~miv.core.callback.BaseCallbackMixin._callback` with those names.
+    :class:`~miv.core.operator_generator.operator.GeneratorOperatorMixin` only.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-
-        self._done_flag_generator_plot = False
-        self._done_flag_firstiter_plot = False
-
-    def reset_callbacks(self, *args: Any, **kwargs: Any) -> None:
-        """Reset callback flags.
-
-        Args:
-            *args: Positional arguments (unused, for compatibility).
-            **kwargs: Keyword arguments. If 'plot' is provided, sets both
-                generator_plot and firstiter_plot flags to that value.
-        """
-        plot_flag = kwargs.get("plot", False)
-        self._done_flag_generator_plot = plot_flag
-        self._done_flag_firstiter_plot = plot_flag
-
-    def _callback_generator_plot(
-        self,
-        iter_index: int,
-        output: "DataTypes",
-        inputs: tuple["DataTypes", ...] | None = None,
-        show: bool = False,
-        save_path: str | pathlib.Path | None = None,
-    ) -> None:
-        if self._done_flag_generator_plot:
-            return
-
-        plotters_for_generator_out = get_methods_from_feature_classes_by_startswith_str(
-            self, "generator_plot_"
-        )
-        for plotter in plotters_for_generator_out:
-            execute_callback(
-                self.logger,
-                plotter,
-                output,
-                inputs,
-                show=show,
-                save_path=save_path,
-                index=iter_index,
-            )
-        plt.close("all")
-
-    def _callback_firstiter_plot(
-        self,
-        output: "DataTypes",
-        inputs: tuple["DataTypes", ...] | None = None,
-        show: bool = False,
-        save_path: str | pathlib.Path | None = None,
-    ) -> None:
-        if self._done_flag_firstiter_plot:
-            return
-
-        plotters_for_generator_out = get_methods_from_feature_classes_by_startswith_str(
-            self, "firstiter_plot_"
-        )
-
-        for plotter in plotters_for_generator_out:
-            execute_callback(
-                self.logger,
-                plotter,
-                output,
-                inputs,
-                show=show,
-                save_path=save_path,
-            )
-        plt.close("all")
+    _callback_group_names: ClassVar[tuple[str, ...]] = (
+        "generator_plot",
+        "firstiter_plot",
+    )
+    _callback_group_argument_transforms = {
+        "generator_plot": _prepare_generator_plot_local,
+        "firstiter_plot": _prepare_firstiter_plot_local,
+    }

--- a/miv/core/operator_generator/operator.py
+++ b/miv/core/operator_generator/operator.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import itertools
 from typing import Any
 from collections.abc import Generator, Iterable
+from abc import abstractmethod
 
 from ..cache_write import persist_cacher_result
 from ..chainable import ChainingMixin
+from ..datatype import DataTypes
 from ..operator.cachable import DataclassCacher
 from ..operator.policy import RunnerBase, VanillaRunner
 from .callback import GeneratorCallbackMixin
@@ -21,6 +23,10 @@ class GeneratorOperatorMixin(ChainingMixin, GeneratorCallbackMixin):
 
         self.tag: str
         self.runner = VanillaGeneratorRunner(self)
+
+    @abstractmethod
+    def __call__(self) -> Generator[DataTypes] | DataTypes:
+        """Execute the operator. Must be implemented by subclasses."""
 
     def __repr__(self) -> str:
         return self.tag
@@ -52,12 +58,21 @@ class GeneratorOperatorMixin(ChainingMixin, GeneratorCallbackMixin):
 
         for idx, (result, zip_arg) in enumerate(zip(gen, tasks, strict=True)):
             persist_cacher_result(self.cacher, result, chunk_index=idx, tag="data")
-            self._callback_generator_plot(
-                idx, result, zip_arg, save_path=self.analysis_path
+            self._callback(
+                "generator_plot",
+                idx,
+                result,
+                zip_arg,
+                save_path=self.analysis_path,
+                set_done=False,
             )
             if idx == 0:
-                self._callback_firstiter_plot(
-                    result, zip_arg, save_path=self.analysis_path
+                self._callback(
+                    "firstiter_plot",
+                    result,
+                    zip_arg,
+                    save_path=self.analysis_path,
+                    set_done=False,
                 )
             yield result
 

--- a/miv/core/operator_generator/policy.py
+++ b/miv/core/operator_generator/policy.py
@@ -94,8 +94,8 @@ class VanillaGeneratorRunner(StreamChunkAlignedGeneratorRunner):
 
             # TODO: add lastiter_plot
             # FIXME
-            self.parent._done_flag_generator_plot = True
-            self.parent._done_flag_firstiter_plot = True
+            self.parent.set_callback_done("generator_plot", True)
+            self.parent.set_callback_done("firstiter_plot", True)
 
         generator = generator_func(*inputs)
         return generator
@@ -177,8 +177,8 @@ class GeneratorRunnerInMultiprocessing(RunnerBase):
             #    yield result
             # TODO: add lastiter_plot
             # FIXME
-            self.parent._done_flag_generator_plot = True
-            self.parent._done_flag_firstiter_plot = True
+            self.parent.set_callback_done("generator_plot", True)
+            self.parent.set_callback_done("firstiter_plot", True)
 
         generator = generator_func(*inputs)
         return generator

--- a/miv/core/pipeline.py
+++ b/miv/core/pipeline.py
@@ -89,8 +89,8 @@ class Pipeline:
         #  Reset all callbacks
         for last_node in self.nodes_to_run:
             for node in topological_sort(last_node):
-                if hasattr(node, "reset_callbacks"):
-                    node.reset_callbacks(plot=skip_plot)
+                if hasattr(node, "set_callback_done"):
+                    node.set_callback_done("plot", skip_plot)
                 if hasattr(node, "set_save_path"):
                     if temporary_directory is not None:
                         node.set_save_path(temporary_directory, cache_directory)

--- a/miv/core/protocol.py
+++ b/miv/core/protocol.py
@@ -74,8 +74,7 @@ class _Node(_Chainable[Any], Protocol):
 
     Matches :func:`miv.core.utils.graph_sorting.topological_sort` (chainable +
     ``flow_blocked``) and :meth:`miv.core.pipeline.Pipeline.run` (``output`` on
-    sink nodes). Optional hooks like ``set_save_path`` / ``reset_callbacks`` are
-    duck-typed at runtime and are not part of this protocol.
+    sink nodes).
     """
 
     def output(self) -> Any: ...

--- a/miv/core/source/node_mixin.py
+++ b/miv/core/source/node_mixin.py
@@ -8,8 +8,7 @@ from typing import TYPE_CHECKING, Any
 from collections.abc import Generator
 
 from ..chainable import ChainingMixin
-from ..operator.callback import BaseCallbackMixin
-from ..loggable import DefaultLoggerMixin
+from ..callback import BaseCallbackMixin
 from ..operator.policy import VanillaRunner
 from .cachable import FunctionalCacher
 
@@ -19,7 +18,7 @@ if TYPE_CHECKING:
     from ..datatype.spikestamps import Spikestamps
 
 
-class DataLoaderMixin(ChainingMixin, BaseCallbackMixin, DefaultLoggerMixin):
+class DataLoaderMixin(ChainingMixin, BaseCallbackMixin):
     """ """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/tests/core/operator_generator/test_generator_operator_caching.py
+++ b/tests/core/operator_generator/test_generator_operator_caching.py
@@ -46,3 +46,17 @@ def test_mock_operator_caching(
     # When cache value is used, plotting should not be executed
     assert mock_generator_plot_test1.call_count == 0
     assert mock_firstiter_plot_test1.call_count == 0
+
+
+def test_generator_operator_flow_blocked_returns_false_on_lookup_error():
+    """Generator flow_blocked should return False when cacher lookup raises."""
+    mock_operator = MockGeneratorOperatorModule()
+    mock_operator.cacher.check_cached = MagicMock(side_effect=AttributeError())
+    assert mock_operator.flow_blocked() is False
+
+
+def test_generator_operator_flow_blocked_returns_false_on_missing_cache_files():
+    """Generator flow_blocked should return False when cache file lookup fails."""
+    mock_operator = MockGeneratorOperatorModule()
+    mock_operator.cacher.check_cached = MagicMock(side_effect=FileNotFoundError())
+    assert mock_operator.flow_blocked() is False

--- a/tests/core/test_callback.py
+++ b/tests/core/test_callback.py
@@ -4,8 +4,9 @@ Tests for callback functionality in operators.
 
 import pytest
 from unittest.mock import Mock, MagicMock
+from types import SimpleNamespace
 
-from miv.core.operator.callback import execute_callback
+from miv.core.callback import BaseCallbackMixin, execute_callback
 
 
 def test_execute_callback_executes_successfully():
@@ -94,3 +95,22 @@ def test_execute_callback_does_not_stop_execution():
     assert result3 is None
     assert execution_count == 3
     assert logger.exception.call_count == 3
+
+
+def test_base_callback_cacher_setter_preserves_policy_and_cache_dir():
+    class MockCallbackNode(BaseCallbackMixin):
+        _callback_group_names = ()
+        _callback_group_argument_transforms = {}
+
+        def __init__(self) -> None:
+            self.tag = "mock-callback-node"
+            super().__init__(cacher=SimpleNamespace(policy="ON", cache_dir="/tmp/cache-a"))
+
+    node = MockCallbackNode()
+    replacement = SimpleNamespace(policy="OFF", cache_dir="/tmp/cache-b")
+
+    node.cacher = replacement  # type: ignore[assignment]
+
+    assert node.cacher is replacement
+    assert node.cacher.policy == "ON"
+    assert node.cacher.cache_dir == "/tmp/cache-a"

--- a/tests/core/test_operator.py
+++ b/tests/core/test_operator.py
@@ -3,6 +3,7 @@ Tests for OperatorMixin.
 """
 
 import pytest
+from unittest.mock import Mock
 
 from miv.core.operator.operator import OperatorMixin
 
@@ -31,3 +32,31 @@ def test_operator_mixin_can_be_used_as_mixin():
     assert operator.tag == "test operator"
     assert hasattr(operator, "runner")
     assert hasattr(operator, "cacher")
+
+
+def test_operator_flow_blocked_returns_false_on_missing_cache_files():
+    """flow_blocked should gracefully handle cacher lookup failures."""
+
+    class MockOperator(OperatorMixin):
+        tag: str = "test operator"
+
+        def __call__(self):
+            return "result"
+
+    operator = MockOperator()
+    operator.cacher.check_cached = Mock(side_effect=FileNotFoundError)  # type: ignore[attr-defined]
+    assert operator.flow_blocked() is False
+
+
+def test_operator_flow_blocked_returns_false_on_attribute_error():
+    """flow_blocked should return False when cacher access raises AttributeError."""
+
+    class MockOperator(OperatorMixin):
+        tag: str = "test operator"
+
+        def __call__(self):
+            return "result"
+
+    operator = MockOperator()
+    operator.cacher.check_cached = Mock(side_effect=AttributeError)  # type: ignore[attr-defined]
+    assert operator.flow_blocked() is False

--- a/tests/core/test_wrappers.py
+++ b/tests/core/test_wrappers.py
@@ -11,12 +11,12 @@ pytestmark = pytest.mark.filterwarnings(
 
 
 class GeneratorPlotMixin:
-    # TODO: This is a temporary solution to avoid issue. calling generator_plot in wrapper should be reconsidered
-    def _callback_generator_plot(self, *args, **kwargs):
-        pass
+    """Minimal mocks: no-op streaming plot groups if something invokes ``_callback``."""
 
-    def _callback_firstiter_plot(self, *args, **kwargs):
-        pass
+    def _callback(self, name: str, *args, **kwargs):
+        if name in ("generator_plot", "firstiter_plot"):
+            return
+        raise NotImplementedError(name)
 
 
 class MockObjectWithoutCache(GeneratorPlotMixin):
@@ -44,7 +44,6 @@ class MockObjectWithoutCache(GeneratorPlotMixin):
 
     def __init__(self, tmp_path):
         self.cacher = self.MockCacher()
-        self.skip_plot = True
         self.analysis_path = tmp_path
 
 

--- a/tests/io/intan/test_intan_mpi.py
+++ b/tests/io/intan/test_intan_mpi.py
@@ -1971,8 +1971,8 @@ def test_mpi_with_configure_load_pipeline_execution(mock_data_intan, mock_mpi_co
     # Mock required attributes for Pipeline
     if not hasattr(mock_data_intan, "_upstream_list"):
         mock_data_intan._upstream_list = []
-    if not hasattr(mock_data_intan, "reset_callbacks"):
-        mock_data_intan.reset_callbacks = MagicMock()
+    if not hasattr(mock_data_intan, "set_callback_done"):
+        mock_data_intan.set_callback_done = MagicMock()
 
     # Configure load with MPI communicator
     mock_data_intan.configure_load(mpi_comm=mock_mpi_comm)
@@ -2018,8 +2018,8 @@ def test_mpi_with_configure_load_parameter_persistence(mock_data_intan, mock_mpi
     # Mock required attributes for Pipeline
     if not hasattr(mock_data_intan, "_upstream_list"):
         mock_data_intan._upstream_list = []
-    if not hasattr(mock_data_intan, "reset_callbacks"):
-        mock_data_intan.reset_callbacks = MagicMock()
+    if not hasattr(mock_data_intan, "set_callback_done"):
+        mock_data_intan.set_callback_done = MagicMock()
 
     # Configure load with MPI communicator
     mock_data_intan.configure_load(mpi_comm=mock_mpi_comm)


### PR DESCRIPTION
## Summary

Extracts shared callback infrastructure into a new `miv/core/callback.py` module introducing `BaseCallbackMixin`, which replaces the previously monolithic `BaseCallbackMixin` in `miv/core/operator/callback.py`. Scalar operator hooks (`after_run`, `plot`) are now handled by `ScalarCallbackMixin` and streaming hooks (`generator_plot`, `firstiter_plot`) by `GeneratorCallbackMixin`, both extending `BaseCallbackMixin` through a declarative group-name and argument-transform mapping. The ad-hoc `_done_flag_*` boolean attributes and `reset_callbacks` method are replaced by a unified `set_callback_done` / `_callback_done` dict, and callback dispatch is unified through a single `_callback(name, ...)` method. `DataLoaderMixin` now imports `BaseCallbackMixin` from the new shared module. Documentation is updated to clarify callback naming conventions for both `OperatorMixin` and `OperatorGeneratorMixin`.

Fixes # (issue)

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation

## Testing

- [x] Tests added/updated

## Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed
- [x] Tests pass locally