### PR TITLE
Refactor node mixins and enhance operator definitions

### DIFF
--- a/miv/core/__init__.py
+++ b/miv/core/__init__.py
@@ -7,12 +7,15 @@ _submodule_paths_for_alias = {
     "datatype.events": ["Events"],
     "datatype.signal": ["Signal"],
     "datatype.spikestamps": ["Spikestamps"],
-    "datatype.node_mixin": ["DataNodeMixin"],
-    "operator.operator": ["OperatorMixin"],
+    "datatype.node_mixin": ["DataNodeBase", "DataNodeMixin"],
+    "operator.operator": ["EagerOpNodeBase", "OperatorMixin"],
     "operator.wrapper": ["cache_call"],
     "source.wrapper": ["cached_method"],
-    "operator_generator.operator": ["GeneratorOperatorMixin"],
+    "operator_generator.operator": [
+        "GeneratorOperatorMixin",
+        "StreamOpNodeBase",
+    ],
     "operator_generator.wrapper": ["cache_generator_call"],
-    "source.node_mixin": ["DataLoaderMixin"],
+    "source.node_mixin": ["DataLoaderMixin", "SourceNodeBase"],
 }
 __getattr__ = getter_upon_call(__name__, _submodule_paths_for_alias)

--- a/miv/core/datatype/node_mixin.py
+++ b/miv/core/datatype/node_mixin.py
@@ -4,7 +4,6 @@ __doc__ = """
 Base mixin for datatype classes that provides chaining capabilities and makes them
 compatible with the pipeline system.
 """
-__all__ = ["DataNodeMixin"]
 
 from typing import TYPE_CHECKING, Any
 from typing_extensions import Self
@@ -35,3 +34,6 @@ class DataNodeMixin(ChainingMixin, DefaultLoggerMixin):
 
     def run(self) -> Self:
         return self.output()
+
+
+DataNodeBase = DataNodeMixin

--- a/miv/core/operator/operator.py
+++ b/miv/core/operator/operator.py
@@ -108,3 +108,6 @@ class OperatorMixin(ChainingMixin, ScalarCallbackMixin):
         args = self.receive()  # Receive data from upstream
         self.set_callback_done("plot", False)  # FIXME
         self._callback("plot", output, args, show=show, save_path=save_path)
+
+
+EagerOpNodeBase = OperatorMixin

--- a/miv/core/operator_generator/operator.py
+++ b/miv/core/operator_generator/operator.py
@@ -102,3 +102,6 @@ class GeneratorOperatorMixin(ChainingMixin, GeneratorCallbackMixin):
             )
             # after_run / plot_* run per chunk inside _wrap_streaming_chunk_side_effects
         return output
+
+
+StreamOpNodeBase = GeneratorOperatorMixin

--- a/miv/core/source/node_mixin.py
+++ b/miv/core/source/node_mixin.py
@@ -49,3 +49,6 @@ class DataLoaderMixin(ChainingMixin, BaseCallbackMixin):
         self, *args: Any, **kwargs: Any
     ) -> Generator[DataTypes] | Spikestamps | Generator[Signal]:
         raise NotImplementedError("load() method must be implemented to be DataLoader.")
+
+
+SourceNodeBase = DataLoaderMixin


### PR DESCRIPTION
## Summary

Introduces semantic base class aliases for the core node types to provide clearer, more descriptive names for use in the public API:

- `DataNodeBase` → `DataNodeMixin`
- `EagerOpNodeBase` → `OperatorMixin`
- `StreamOpNodeBase` → `GeneratorOperatorMixin`
- `SourceNodeBase` → `DataLoaderMixin`

These aliases are exported from `miv.core`, allowing users to reference node base classes by names that better reflect their role in the pipeline system.

Fixes # (issue)

## Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation

## Testing

- [x] Tests added/updated

## Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed
- [x] Tests pass locally