### PR TITLE
Update documentation and refactor operator mixins

### DIFF
--- a/docs/tutorial/core_concept.md
+++ b/docs/tutorial/core_concept.md
@@ -20,7 +20,7 @@ Each nodes are isolated, and they can be chained to form a graph of data process
 Some node may only have input (upstream) connections, and they are called `end nodes`, such as plotter or visualizer nodes that does not produce any output.
 Generally, a node can form both upstream and downstream connections, where operator are in charge of processing the data and producing the output.
 
-```{mermaid]
+```mermaid
 graph LR
     Data("Data Node")
     Operator("Operator Node")
@@ -29,13 +29,13 @@ graph LR
     Operator -- ">>" --> End
 ```
 
-This diagram illustrates how a data node (such as `Spikestamps` or `IONode`) can be chained to an operator node using the `>>` operator in MiV-OS pipelines.
+This diagram illustrates how a data node (such as `Spikestamps` or a loader node) can be chained to an operator node using the `>>` operator in MiV-OS pipelines.
 
 ## Core Module
 
-The `core` module provides the foundational tools for building data processing pipelines. To build custom nodes, an operator mixin is provided for each type.
+The `core` module provides the foundational tools for building data processing pipelines. To build custom nodes, subclass the appropriate **node base** from `miv.core` (see root **`CONTEXT.md`** for the full glossary). Older examples may use legacy `*Mixin` names for the same classes; **`CONTEXT.md`** lists the preferred **`*NodeBase`** imports.
 
-### Datatype (Source)
+### Datatype (data nodes)
 
 Extended data types that inherit from native Python or NumPy types with additional functionality for electrophysiology data.
 
@@ -51,11 +51,11 @@ Extended data types that inherit from native Python or NumPy types with addition
   - Represents discrete events in time
   - Can be binned into Signal format
 
-All datatypes inherit from `DataNodeMixin`, which provides chaining capabilities and makes them compatible with the pipeline system.
+Built-in datatypes subclass **`DataNodeBase`** (legacy name **`DataNodeMixin`**), which provides chaining and pipeline compatibility.
 
-### OperatorMixin
+### EagerOpNodeBase (non-streaming operators)
 
-The `OperatorMixin` is a mixin to create general purpose `node` that can be used in a pipeline. Operators are composed of several features that provide multiple capabilities.
+**`EagerOpNodeBase`** is the base class for general-purpose **eager** (non-streaming) operators: each run produces one full result from **`output()`**. (Legacy name **`OperatorMixin`** — same class.)
 
 **Chaining**: Operators can be chained using the `>>` operator:
 
@@ -78,30 +78,32 @@ This creates a dependency graph where `operator1` is upstream of `operator2`, et
 - `plot_*`: Methods called for visualization (can be skipped with `skip_plot=True` passed to `Pipeline`)
 - Callbacks can be dynamically added using the `<<` operator
 
-#### Adding callbacks: `OperatorMixin` vs `OperatorGeneratorMixin`
+#### Adding callbacks: `EagerOpNodeBase` vs `StreamOpNodeBase`
 
 Use callback name prefixes to register post-processing hooks:
 
-- `OperatorMixin` (scalar output):
+- **`EagerOpNodeBase`** (single `output()`):
   - `after_run_*` receives the operator output.
   - `plot_*` receives `(output, inputs, show=False, save_path=None)`.
-- `OperatorGeneratorMixin` (streaming output):
+- **`StreamOpNodeBase`** (streaming `output()`):
   - `generator_plot_*` runs for each yielded chunk and receives
     `(output, inputs, show=False, save_path=None, index=<iter>)`.
   - `firstiter_plot_*` runs on the first yielded chunk and receives
     `(output, inputs, show=False, save_path=None)`.
 
 ```python
-# Scalar operator callbacks
-class MyScalarOp(...):
+from miv.core import EagerOpNodeBase, StreamOpNodeBase
+
+# Eager operator callbacks
+class MyEagerOp(EagerOpNodeBase):
     def after_run_report(self, output):
         ...
 
     def plot_summary(self, output, inputs, show=False, save_path=None):
         ...
 
-# Generator operator callbacks
-class MyGeneratorOp(...):
+# Streaming operator callbacks
+class MyStreamOp(StreamOpNodeBase):
     def generator_plot_trace(self, output, inputs, show=False, save_path=None, index=0):
         ...
 
@@ -117,15 +119,18 @@ You can also attach external functions with `<<`; naming still controls when the
 - `StrictMPIRunner`: MPI-based execution where each rank processes independently
 - `SupportMPIMerge`: MPI execution with automatic result merging
 
-### OperatorGeneratorMixin
+### StreamOpNodeBase (streaming operators)
 
-Specialized operators for generator-based processing. Most of the features are similar to `OperatorMixin`, but with additional features for generator-based processing.
-Generator operators are useful for processing data streams or when operations naturally yield multiple results.
+**`StreamOpNodeBase`** is the base class for operators whose **`output()`** is a **generator** (chunked / streaming results). (Legacy name **`GeneratorOperatorMixin`** — same class.)
 
-**Runner Policies**: Different execution strategies for parallelization:
+Most behavior matches eager operators, but streaming paths use generator-specific runners and per-chunk cache writes. When results are **not** loaded from cache, a streaming operator **must** receive **upstream** iterable inputs (the implementation requires at least one upstream for the streaming execution path).
 
-- `VanillaGeneratorRunner`: Default sequential execution (supports MPI broadcast if available)
-- `MultiprocessingGeneratorRunner`: Parallel execution using Python multiprocessing
+**Runner Policies**:
+
+- `VanillaGeneratorRunner`: Default sequential execution over zipped upstream iterables (MPI behavior differs from `VanillaRunner` on eager nodes; see module docstrings)
+- `GeneratorRunnerInMultiprocessing`: Parallel batches via `multiprocessing` (does not use the same chunk-alignment contract as `VanillaGeneratorRunner`; see `miv.core.operator_generator.policy`)
+
+The **`@cache_generator_call`** decorator is **deprecated**; prefer the current **`StreamOpNodeBase`** / **`__call__`** patterns described in **`CONTEXT.md`**.
 
 ## Pipeline
 

--- a/docs/tutorial/spike_sorting.md
+++ b/docs/tutorial/spike_sorting.md
@@ -65,17 +65,16 @@ plt.show()
 ## Build Operator
 
 As an example, let's build a simple operator that will print out the shape of the cutouts.
-The easiest way to build an operator is to make `dataclass` and inherit the `OperatorMixin` class.
-The `OperatorMixin` allow us to use the `dataclass` object as a part of a `Pipeline`.
+The easiest way to build an operator is to make a `dataclass` and inherit **`EagerOpNodeBase`** (legacy name **`OperatorMixin`** — same class).
 
-The mixin `OperatorMixin` provides most of the necessary variables and methods to build an operator, except for the `tag`. The `tag` is used to identify the operator, and use to name the output files and directory. To initialize the operator, we will use the `__post_init__` method.
+**`EagerOpNodeBase`** provides most of the necessary variables and methods to build an operator, except for the `tag`. The `tag` is used to identify the operator, and use to name the output files and directory. To initialize the operator, we will use the `__post_init__` method.
 
 ```{code-cell} ipython3
 from dataclasses import dataclass
-from miv.core import OperatorMixin
+from miv.core import EagerOpNodeBase
 
 @dataclass
-class CutoutShape(OperatorMixin):
+class CutoutShape(EagerOpNodeBase):
     tag = "cutout shape"
 
     def __post_init__(self):
@@ -125,7 +124,7 @@ from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
 
 @dataclass
-class PCAClustering(OperatorMixin):
+class PCAClustering(EagerOpNodeBase):
     n_clusters: int = 3
     n_pca_components: int = 2
     tag = "pca clustering"

--- a/miv/core/__init__.py
+++ b/miv/core/__init__.py
@@ -7,15 +7,26 @@ _submodule_paths_for_alias = {
     "datatype.events": ["Events"],
     "datatype.signal": ["Signal"],
     "datatype.spikestamps": ["Spikestamps"],
-    "datatype.node_mixin": ["DataNodeBase", "DataNodeMixin"],
-    "operator.operator": ["EagerOpNodeBase", "OperatorMixin"],
-    "operator.wrapper": ["cache_call"],
+    "datatype.node_mixin": [
+        "DataNodeBase",  # public name
+        "DataNodeMixin",  # internal name
+    ],
+    "operator.operator": [
+        "EagerOpNodeBase",  # public name
+        "OperatorMixin",  # internal name
+    ],
+    "operator.wrapper": ["cache_call"],  # Deprecated. Keep for backward compatibility.
     "source.wrapper": ["cached_method"],
     "operator_generator.operator": [
-        "GeneratorOperatorMixin",
-        "StreamOpNodeBase",
+        "StreamOpNodeBase",  # public name
+        "GeneratorOperatorMixin",  # internal name
     ],
-    "operator_generator.wrapper": ["cache_generator_call"],
-    "source.node_mixin": ["DataLoaderMixin", "SourceNodeBase"],
+    "operator_generator.wrapper": [
+        "cache_generator_call"
+    ],  # Deprecated. Keep for backward compatibility.
+    "source.node_mixin": [
+        "SourceNodeBase",  # public name
+        "DataLoaderMixin",  # internal name
+    ],
 }
 __getattr__ = getter_upon_call(__name__, _submodule_paths_for_alias)


### PR DESCRIPTION
## Summary

Updates documentation and public API references to use the preferred `*NodeBase` naming convention (`EagerOpNodeBase`, `StreamOpNodeBase`, `DataNodeBase`, `SourceNodeBase`) throughout tutorials and the `miv/core` module, while retaining legacy `*Mixin` aliases for backward compatibility. Fixes a broken mermaid code fence syntax in `core_concept.md` and clarifies streaming vs. eager operator behavior, runner policies, and the deprecation of `@cache_generator_call`.

Fixes # (issue)

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation

## Testing

- [ ] Tests added/updated

## Checklist

- [ ] Code follows style guidelines
- [x] Self-reviewed
- [x] Tests pass locally