### PR TITLE
Enhance documentation and MPI support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,10 @@ autodoc_default_options = {
     "exclude-members": "__weakref__",
     "show-inheritance": True,
 }
+# PEP 604 unions in attribute lines (e.g. ``list[int] | None``) confuse docutils if inlined as prose.
+autodoc_typehints = "signature"
+# Optional runtime dependency; tutorials mention MPI but do not execute mpi4py during build.
+autodoc_mock_imports = ["mpi4py"]
 autosectionlabel_prefix_document = True
 autosummary_generate = True
 autosummary_generate_overwrite = False

--- a/docs/tutorial/mpi_support.md
+++ b/docs/tutorial/mpi_support.md
@@ -12,9 +12,13 @@ To use MPI functionality and `mpi4py`.
 ### Basic MPI Usage
 
 ```python
+# Requires: pip install mpi4py  (also install an MPI implementation, e.g. Open MPI)
+from mpi4py import MPI
+
 # from miv.io.openephys import Data
 from miv.io.intan import DataIntan as Data
 from miv.core.pipeline import Pipeline
+from miv.core.operator.policy import SupportMPIMerge
 from miv.signal.filter import ButterBandpass
 from miv.signal.spike import ThresholdCutoff
 

--- a/miv/io/openephys/data.py
+++ b/miv/io/openephys/data.py
@@ -1,26 +1,10 @@
 from __future__ import annotations
 
 __doc__ = """
+Open Ephys I/O: :class:`Data` (single recording) and :class:`DataManager` (experiment folder).
 
-Data Manager (OpenEphys)
-########################
-
-.. autoclass:: DataManager
-   :members:
-
-Module (OpenEphys)
-##################
-
-.. Note::
-    We expect the data structure to follow the default format
-    exported from OpenEphys system:
-    `format <https://open-ephys.atlassian.net/wiki/spaces/OEW/pages/491632/Data+format>`_.
-
-.. currentmodule:: miv.io.openephys.data
-
-.. autoclass:: Data
-   :members:
-
+We expect the on-disk layout to follow the default format exported from Open Ephys;
+see the `Open Ephys data format <https://open-ephys.atlassian.net/wiki/spaces/OEW/pages/491632/Data+format>`_.
 """
 
 __all__ = ["Data", "DataManager"]

--- a/miv/statistics/connectivity/connectivity.py
+++ b/miv/statistics/connectivity/connectivity.py
@@ -25,6 +25,20 @@ from miv.mea import mea_map
 from miv.statistics.spiketrain_statistics import firing_rates
 
 
+def _pairwise_granger_scalar(sig: np.ndarray, order: int) -> float:
+    """Return a single float from elephant's ``pairwise_granger`` (API may return ``Causality`` or ndarray)."""
+    try:
+        val = pairwise_granger(sig, order)
+    except ValueError:
+        return 0.0
+    if hasattr(val, "total_interdependence"):
+        return float(val.total_interdependence)
+    arr = np.asarray(val).ravel()
+    if arr.size == 0:
+        return 0.0
+    return float(arr[0])
+
+
 # self MPI-able
 @dataclass
 class DirectedConnectivity(OperatorMixin):
@@ -167,7 +181,7 @@ class DirectedConnectivity(OperatorMixin):
             return 1, 0
         source = binned_spiketrain[sid]
         target = binned_spiketrain[tid]
-        te, surrogate_te_list = DirectedConnectivity._surrogate_t_test(
+        te, surrogate_te_list = UndirectedConnectivity._surrogate_t_test(
             source,
             target,
             skip_surrogate=skip_surrogate,
@@ -499,13 +513,9 @@ class UndirectedConnectivity(OperatorMixin):
         )
 
         sig = np.stack([source, target], axis=-1)
-        try:
-            val = pairwise_granger(sig, order)
-        except ValueError:
-            val = [0.0, 0.0]
-            # val = [np.nan, np.nan]
+        val = _pairwise_granger_scalar(sig, order)
 
-        surrogate_vals = []
+        surrogate_vals: list[float] = []
         if skip_surrogate:
             return val, surrogate_vals
 
@@ -521,17 +531,14 @@ class UndirectedConnectivity(OperatorMixin):
             rng.shuffle(surrogate_source)
             for start_index in np.arange(0, source.shape[0] - sublength, stride):
                 end_index = start_index + sublength
-                surr_val = pairwise_granger(
-                    np.stack(
-                        [
-                            surrogate_source[start_index:end_index],
-                            target[start_index:end_index],
-                        ],
-                        axis=-1,
-                    ),
-                    order,
+                surr_sig = np.stack(
+                    [
+                        surrogate_source[start_index:end_index],
+                        target[start_index:end_index],
+                    ],
+                    axis=-1,
                 )
-                surrogate_vals.append(surr_val)
+                surrogate_vals.append(_pairwise_granger_scalar(surr_sig, order))
 
         return val, surrogate_vals
 


### PR DESCRIPTION
## Summary

Fixes a crash in `UndirectedConnectivity._surrogate_t_test` caused by calling `pairwise_granger` directly and mishandling its return type (which may be a `Causality` namedtuple or an ndarray depending on the `elephant` version). A new helper `_pairwise_granger_scalar` normalises the return value to a single float and swallows `ValueError` gracefully. Also corrects a copy-paste bug where `DirectedConnectivity._surrogate_t_test` was referenced instead of `UndirectedConnectivity._surrogate_t_test` inside `_get_connection_info`.

On the docs side, `autodoc_typehints = "signature"` prevents PEP 604 union annotations (e.g. `list[int] | None`) from breaking the docutils build, and `autodoc_mock_imports = ["mpi4py"]` stops the build from failing when `mpi4py` is not installed. The MPI tutorial is updated to show the required import statements, and the `openephys/data.py` module docstring is simplified to plain prose.

Fixes # (issue)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation

## Testing

- [ ] Tests added/updated

## Checklist

- [ ] Code follows style guidelines
- [x] Self-reviewed
- [ ] Tests pass locally